### PR TITLE
Image moderation Rekognition

### DIFF
--- a/flask_backend/routes/upload_routes.py
+++ b/flask_backend/routes/upload_routes.py
@@ -3,6 +3,7 @@ import boto3
 import os
 from datetime import datetime
 from services.db_service import get_collection
+from services.rekognition_service import moderate_image_s3
 
 upload_bp = Blueprint('upload', __name__)
 
@@ -56,11 +57,16 @@ def generate_upload_url():
             return jsonify({'error': 'No matching location found'}), 404
 
         # 4. Setup S3
+        aws_key = os.environ.get('AWS_ACCESS_KEY_ID')
+        aws_secret = os.environ.get('AWS_SECRET_ACCESS_KEY')
+        region = os.environ.get('S3_REGION')
+        if not all([aws_key, aws_secret, region]):
+            raise EnvironmentError("Missing AWS credentials or region in environment variables.")
         s3_client = boto3.client(
             's3',
-            aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-            aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
-            region_name=os.environ.get('S3_REGION')
+            aws_access_key_id=aws_key,
+            aws_secret_access_key=aws_secret,
+            region_name=region
         )
         bucket_name = os.environ.get('S3_BUCKET_NAME')
 
@@ -76,16 +82,31 @@ def generate_upload_url():
             },
             ExpiresIn=3600
         )
-        public_url = f"https://{bucket_name}.s3.{os.environ.get('S3_REGION')}.amazonaws.com/{key}"
+        public_url = f"https://{bucket_name}.s3.{region}.amazonaws.com/{key}"
 
-        # 6. Add image object to Images array
+        # 6.1 Moderate image using Rekognition
+        s3_key = key  # Already constructed above
+        try:
+            is_clean, labels = moderate_image_s3(bucket_name, s3_key)
+        except Exception as e:
+            print(f"Error in Rekognition: {e}")
+            return jsonify({'error': 'Error in Rekognition'}), 500
+
+        if not is_clean:
+            # Delete the image from S3
+            s3_client.delete_object(Bucket=bucket_name, Key=s3_key)
+            return jsonify({
+                'error': 'Image failed moderation and was deleted.'
+            }), 400
+
+        # 6.2 Add image object to Images array (only if clean)
         image_data = {
             "image_url": public_url,
             "image_upload_time": datetime.utcnow().isoformat() + "Z",
-            "approved_status": False,
+            "approved_status": False,  # Always False, pending admin approval
             "image_approved_time": None,
             "device_id": device_id,
-            "username": username
+            "username": username,
         }
 
         result = collection.update_one(

--- a/flask_backend/services/rekognition_service.py
+++ b/flask_backend/services/rekognition_service.py
@@ -1,0 +1,28 @@
+import boto3
+import os
+
+def moderate_image_s3(bucket_name, image_key, min_confidence=80):
+    """
+    Checks an image in S3 for inappropriate content using AWS Rekognition.
+    Returns (is_clean, labels):
+      - is_clean: True if no inappropriate content, False otherwise
+      - labels: List of moderation labels (if any)
+    """
+    rekognition = boto3.client(
+        'rekognition',
+        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+        region_name=os.environ.get('S3_REGION')
+    )
+    response = rekognition.detect_moderation_labels(
+        Image={
+            'S3Object': {
+                'Bucket': bucket_name,
+                'Name': image_key
+            }
+        },
+        MinConfidence=min_confidence
+    )
+    labels = response.get('ModerationLabels', [])
+    is_clean = len(labels) == 0
+    return is_clean 

--- a/flask_backend/tests/test_rekognition_service.py
+++ b/flask_backend/tests/test_rekognition_service.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Add the parent directory to sys.path to import rekognition_service
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from services import rekognition_service
+
+class TestModerateImageS3(unittest.TestCase):
+    @patch('services.rekognition_service.boto3.client')
+    def test_image_is_clean(self, mock_boto_client):
+        mock_rekognition = MagicMock()
+        mock_rekognition.detect_moderation_labels.return_value = {'ModerationLabels': []}
+        mock_boto_client.return_value = mock_rekognition
+        is_clean = rekognition_service.moderate_image_s3('bucket', 'key')
+        self.assertTrue(is_clean)
+
+    @patch('services.rekognition_service.boto3.client')
+    def test_image_is_not_clean(self, mock_boto_client):
+        mock_rekognition = MagicMock()
+        mock_rekognition.detect_moderation_labels.return_value = {
+            'ModerationLabels': [{'Name': 'Explicit Nudity', 'Confidence': 99.0}]
+        }
+        mock_boto_client.return_value = mock_rekognition
+        is_clean = rekognition_service.moderate_image_s3('bucket', 'key')
+        self.assertFalse(is_clean)
+
+    @patch('services.rekognition_service.boto3.client')
+    def test_aws_error(self, mock_boto_client):
+        mock_rekognition = MagicMock()
+        mock_rekognition.detect_moderation_labels.side_effect = Exception('AWS error')
+        mock_boto_client.return_value = mock_rekognition
+        # The original function does not handle exceptions, so this will raise
+        with self.assertRaises(Exception):
+            rekognition_service.moderate_image_s3('bucket', 'key')
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_env_vars(self):
+        # The original function does not check for missing env vars, but if you add that, this will test it
+        with self.assertRaises(Exception):
+            rekognition_service.moderate_image_s3('bucket', 'key')
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
Added Image Moderation

Flow:
1. User uploads image to Amazon S3
2. Image is passed to Amazon Rekognition Moderation service
3. If number of moderated labes > 0, then image is deleted off amazon s3, marker database is not modified and user receives an error: "Upload rejected to moderation policy"
4. If number of moderated labels = 0, image is uploaded to s3, but approved status is still maintained as False for the image- pending approval through backend